### PR TITLE
Fix failing test by assuming NZ timezone

### DIFF
--- a/src/test/java/org/concordion/cubano/utils/ISODateTimeFormatTest.java
+++ b/src/test/java/org/concordion/cubano/utils/ISODateTimeFormatTest.java
@@ -6,15 +6,14 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Locale;
+import java.util.TimeZone;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ISODateTimeFormatTest {
 
-    // TODO: Andrew - these tests assume a NZ locale. Let's add other locales.
     public ISODateTimeFormatTest() {
-        Locale.setDefault(new Locale("en", "NZ"));
+        TimeZone.setDefault(TimeZone.getTimeZone("NZ"));
     }
 
     @Test


### PR DESCRIPTION
This one really does fix it :)

I am actually wondering how relevant the ISODateFormat class is to Cubano though? Is it used by any core Cubano code, or is it an independent utility. Seeing reference to BPM date formats points to something that could be removed from the codebase?

Previous fix assumed Locale, which was incorrect.
Failing test was reproduced by passing the system property .
This fix sets the timezone to NZ.