### PR TITLE
Upgrade to yandex htmlelements v1.19

### DIFF
--- a/cubano-webdriver/build.gradle
+++ b/cubano-webdriver/build.gradle
@@ -7,16 +7,10 @@ dependencies {
     compile "org.seleniumhq.selenium:selenium-java:3.8.1"
     
     // Html Elements
-    //compile('ru.yandex.qatools.htmlelements:htmlelements-java:1.18') {
-    //    exclude group: 'org.seleniumhq.selenium', module: 'selenium-java'
-    //}
-    
-    // This uses Jitpack to build and import multiple modules from Github
-    // TODO Can revert to above once 1.19 is released - and remove jitpack from root build.gradle and also release block below
-    compile('com.github.yandex-qatools.htmlelements:htmlelements-java:master-SNAPSHOT') {
+    compile('ru.yandex.qatools.htmlelements:htmlelements-java:1.19') {
         exclude group: 'org.seleniumhq.selenium', module: 'selenium-java'
     }
-
+    
     compile 'org.jsoup:jsoup:1.8.3'
 
     // TODO remove dependencies


### PR DESCRIPTION
[Request for new release](https://github.com/yandex-qatools/htmlelements/issues/143) has been resolved and [new release v1.19](https://github.com/yandex-qatools/htmlelements/releases) of [HtmlElements](https://github.com/yandex-qatools/htmlelements) has been created.

Updated build.gradle file to refer to lastest build.

A consumer project of Cubano has been configured to build using this branch (with update to latest HtmlElements).  Build successful.