### PR TITLE
Remove Jitpack repo.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,6 @@ subprojects {
     targetCompatibility = 1.8
     
     repositories {
-        // Only required while webdriver project waiting for htmlelements to be published
-        maven { url "https://jitpack.io" }
         mavenCentral()
     }
 


### PR DESCRIPTION
Remove JitPack repo as no longer required, now that a version of [Yandex HtmlElements](https://github.com/yandex-qatools/htmlelements)  has been released.