### PR TITLE
Travis changes to include Javadoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,11 @@ jdk:
 
 script:
   - ./gradlew clean check aggregateJavadocs
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: java
 jdk:
   - oraclejdk9
   - oraclejdk8
+
+script:
+  - ./gradlew clean check aggregateJavadocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew clean check aggregateJavadocs
+  - ./gradlew clean check
+  - # gradlew aggregateJavadocs is failing with JDK9 with error "package javax.xml.bind is declared in module java.xml.bind, which is not in the module graph"
+  - jdk_switcher use oraclejdk8
+  - ./gradlew aggregateJavadocs
+
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
When getting to a release, I am often finding that Javadoc errors prevent the release. Adding to the CI build will help to detect those earlier.

This also includes changes to speed up the Travis build.

@jimmykemp - there is a Javadoc issue with making the new release that this should highlight. We'll need to trigger the Travis build manually after merging this PR.