### PR TITLE
Upgrade FF browser proxy capabilities - allow FF to go through a proxy.

### DIFF
--- a/cubano-config/src/main/java/org/concordion/cubano/config/ProxyConfig.java
+++ b/cubano-config/src/main/java/org/concordion/cubano/config/ProxyConfig.java
@@ -176,10 +176,21 @@ public class ProxyConfig {
                 proxyPassword = System.getenv("HTTP_PROXY_PASS");
             }
 
-            nonProxyHosts = System.getenv("NO_PROXY");
+			String envVarNoProxy = System.getenv("NO_PROXY");
+			if (envVarNoProxy != null && !envVarNoProxy.isEmpty()) {
+				nonProxyHosts = envVarNoProxy;
+			}
         }
     }
 
+	/**
+	 * Environment variable HTTP_PROXY should be set like:
+	 * http://[username]:[password]@[proxyHost]:[proxyPort]
+	 * 
+	 * e.g. http://myusername:mypassword@corporateproxy.com:8080
+	 * 
+	 * @return represents a Uniform Resource Locator
+	 */
     private URL getProxyUrl() {
         String proxyInput = System.getenv("HTTP_PROXY");
 

--- a/cubano-config/src/main/java/org/concordion/cubano/config/ProxyConfig.java
+++ b/cubano-config/src/main/java/org/concordion/cubano/config/ProxyConfig.java
@@ -176,10 +176,7 @@ public class ProxyConfig {
                 proxyPassword = System.getenv("HTTP_PROXY_PASS");
             }
 
-			String envVarNoProxy = System.getenv("NO_PROXY");
-			if (envVarNoProxy != null && !envVarNoProxy.isEmpty()) {
-				nonProxyHosts = envVarNoProxy;
-			}
+			nonProxyHosts = System.getenv("NO_PROXY");
         }
     }
 

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/FirefoxBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/FirefoxBrowserProvider.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Map;
 
 import org.openqa.selenium.InvalidArgumentException;
-import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
@@ -112,37 +111,6 @@ public class FirefoxBrowserProvider extends LocalBrowserProvider {
     	}
 	}
 
-    @Override
-    protected void addProxyCapabilities(MutableCapabilities capabilities) {
-    	if (getPropertyAsBoolean("useLegacyDriver", "false")) {
-    		super.addProxyCapabilities(capabilities);
-    	} else {
-            // TODO Proxy support only comming with Firefox 57. Cannot test yet as geckodriver win32 0.19.0 not available
-            // WebDriverConfig config = WebDriverConfig.getInstance();
-            //
-            // if (!config.isProxyRequired()) {
-            // return;
-            // }
-            //
-            // String proxy = config.getProxyHost();
-            // int port = config.getProxyPort();
-            // String browserNonProxyHosts = config.getNonProxyHosts();
-            //
-            // JsonObject json = new JsonObject();
-            //
-            // json.addProperty("proxyType", "manual");
-            // json.addProperty("httpProxy", proxy);
-            // json.addProperty("httpProxyPort", port);
-            // json.addProperty("ftpProxy", proxy);
-            // json.addProperty("ftpProxyPort", port);
-            // json.addProperty("sslProxy", proxy);
-            // json.addProperty("sslProxyPort", port);
-            //
-            // capabilities.setCapability(CapabilityType.PROXY, proxy.toString());
-            // capabilities.setCapability(CapabilityType.ACCEPT_SSL_CERTS, true);
-        }
-    }
-    
 	private void addProfileProperties(FirefoxProfile profile) {
         Map<String, String> properties = getPropertiesStartingWith("profile.");
 

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
@@ -132,7 +132,7 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
         proxy.setFtpProxy(browserProxy);
         proxy.setSslProxy(browserProxy);
 
-        if (!browserNonProxyHosts.isEmpty()) {
+		if (browserNonProxyHosts != null && !browserNonProxyHosts.isEmpty()) {
 			// proxy.setNoProxy - defines a String, but expects an array (as per
 			// https://w3c.github.io/webdriver/webdriver-spec.html#proxy)
 			// BUG raised at - https://github.com/mozilla/geckodriver/issues/1164

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
@@ -133,6 +133,10 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
         proxy.setSslProxy(browserProxy);
 
         if (!browserNonProxyHosts.isEmpty()) {
+			// proxy.setNoProxy - defines a String, but expects an array (as per
+			// https://w3c.github.io/webdriver/webdriver-spec.html#proxy)
+			// BUG raised at - https://github.com/mozilla/geckodriver/issues/1164
+			// Workaround defined at - https://github.com/SeleniumHQ/selenium/issues/5004
             proxy.setNoProxy(browserNonProxyHosts);
         }
 


### PR DESCRIPTION
This update now allows FF browser tests to go through a Proxy.

fyi - reverted one of the earlier changes on ProxyConfig, and fixed instead in LocalBrowserProvider

1. Remove override of method 'addProxyCapabilities' from FirefoxBrowserProvider.  Now that Firefox 57 and geckodriver win32 0.19.0 are available, no longer require the override.

2. LocalBrowserProvider: There is a bug identified on proxy.setNoProxy.  W3C defines as String array, interface defined as String.  Notes added - may have to look at workaround option.  Added protection around method to ensure that only a 'populated' value will be passed, which allows current implementation to work.  Nevertheless, this area still requires some additional work if wishing to set non proxy hosts.