### PR TITLE
Clean up browser driver

### DIFF
--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
@@ -234,7 +234,7 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
         if (driverPath != null) {
             boolean isDebug = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0;
 
-            if (isDebug) {
+            if (WebDriverConfig.getInstance().isCleanupDriver() || isDebug) {
                 try {
                     String cmd;
                     boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
@@ -228,10 +228,20 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
 
     public void cleanup() {
         if (driverPath != null) {
-            try {
-                Runtime.getRuntime().exec("taskkill /F /IM " + new File(driverPath).getName());
-            } catch (IOException e) {
-                throw new RuntimeException("Unable to close browser driver", e);
+            boolean isDebug = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0;
+
+            if (isDebug) {
+                try {
+                    boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;
+
+                    if (isWindows) {
+                        Runtime.getRuntime().exec("taskkill /F /IM " + new File(driverPath).getName());
+                    } else {
+                        Runtime.getRuntime().exec("pkill -f \"" + new File(driverPath).getName() + "\"");
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException("Unable to close browser driver", e);
+                }
             }
         }
     }

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
@@ -16,6 +16,8 @@ import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.CapabilityType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.github.bonigarcia.wdm.Architecture;
 import io.github.bonigarcia.wdm.WebDriverManager;
@@ -26,6 +28,8 @@ import io.github.bonigarcia.wdm.WebDriverManager;
  * @author Andrew Sumner
  */
 public abstract class LocalBrowserProvider implements BrowserProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalBrowserProvider.class);
+
     private PropertyLoader propertyLoader = Config.getInstance().getPropertyLoader();
     private ProxyConfig proxyConfig = Config.getInstance().getProxyConfig();
     private WebDriverConfig config = WebDriverConfig.getInstance();
@@ -232,15 +236,19 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
 
             if (isDebug) {
                 try {
+                    String cmd;
                     boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;
 
                     if (isWindows) {
-                        Runtime.getRuntime().exec("taskkill /F /IM " + new File(driverPath).getName());
+                        cmd = String.format("taskkill /F /IM %s", new File(driverPath).getName());
                     } else {
-                        Runtime.getRuntime().exec("pkill -f \"" + new File(driverPath).getName() + "\"");
+                        cmd = String.format("pkill -f \"%s\"", new File(driverPath).getName());
                     }
+
+                    LOGGER.debug("Cleaning up any orphaned browser drivers using command: {}", cmd);
+                    Runtime.getRuntime().exec(cmd);
                 } catch (IOException e) {
-                    throw new RuntimeException("Unable to close browser driver", e);
+                    LOGGER.warn("Unable to terminate browser driver", e);
                 }
             }
         }

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/LocalBrowserProvider.java
@@ -33,7 +33,7 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
     private PropertyLoader propertyLoader = Config.getInstance().getPropertyLoader();
     private ProxyConfig proxyConfig = Config.getInstance().getProxyConfig();
     private WebDriverConfig config = WebDriverConfig.getInstance();
-    protected String driverPath = null;
+    private String driverPath = null;
 
     /**
      * 
@@ -106,7 +106,7 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
      * 
      * @return Path to browser executable
      */
-    public String getBrowserExe() {
+    protected String getBrowserExe() {
         String localBrowserExe = propertyLoader.getProperty(getBrowserName() + ".exe", null);
 
         if (!localBrowserExe.isEmpty()) {
@@ -232,9 +232,7 @@ public abstract class LocalBrowserProvider implements BrowserProvider {
 
     public void cleanup() {
         if (driverPath != null) {
-            boolean isDebug = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments().toString().indexOf("-agentlib:jdwp") > 0;
-
-            if (WebDriverConfig.getInstance().isCleanupDriver() || isDebug) {
+            if (WebDriverConfig.getInstance().isCleanupDriver()) {
                 try {
                     String cmd;
                     boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0;

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
@@ -182,10 +182,10 @@ public class Browser {
         	}
 
             // Calling close then quit as this can help closing driver processes that sometimes get left behind if just calling quit
-            getActiveDriver().close();
+            // getActiveDriver().close();
             getActiveDriver().quit();
         } catch (Exception ex) {
-            LOGGER.debug("Exception attempting to quit the browser: " + ex.getMessage());
+            LOGGER.warn("Exception attempting to quit the browser: " + ex.getMessage());
         }
 
         this.eventFiringDriver = null;

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
@@ -181,8 +181,6 @@ public class Browser {
         		this.eventFiringDriver.unregister(this.eventListener);
         	}
 
-            // Calling close then quit as this can help closing driver processes that sometimes get left behind if just calling quit
-            // getActiveDriver().close();
             getActiveDriver().quit();
         } catch (Exception ex) {
             LOGGER.warn("Exception attempting to quit the browser: " + ex.getMessage());

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
@@ -131,7 +131,7 @@ public class Browser {
     }
 
     private WebDriver getActiveDriver() {
-    	return this.eventFiringDriver == null ? this.wrappedDriver : this.eventFiringDriver;
+        return this.eventFiringDriver == null ? this.wrappedDriver : this.eventFiringDriver;
     }
     
     /**

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/Browser.java
@@ -180,6 +180,9 @@ public class Browser {
         	if (this.eventListener != null) {
         		this.eventFiringDriver.unregister(this.eventListener);
         	}
+
+            // Calling close then quit as this can help closing driver processes that sometimes get left behind if just calling quit
+            getActiveDriver().close();
             getActiveDriver().quit();
         } catch (Exception ex) {
             LOGGER.debug("Exception attempting to quit the browser: " + ex.getMessage());

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/config/WebDriverConfig.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/config/WebDriverConfig.java
@@ -26,7 +26,8 @@ public final class WebDriverConfig {
     private String browserPosition;
     private boolean browserMaximized;
     private boolean eventLoggingEnabled;
-
+    private boolean cleanupDriver;
+    
     private String remoteUserName;
     private String remoteApiKey;
 
@@ -92,7 +93,8 @@ public final class WebDriverConfig {
         browserPosition = propertyLoader.getProperty("webdriver.browser.position", null);
         browserMaximized = propertyLoader.getPropertyAsBoolean("webdriver.browser.maximized", "false");
         eventLoggingEnabled = propertyLoader.getPropertyAsBoolean("webdriver.event.logging", "true");
-
+        cleanupDriver = propertyLoader.getPropertyAsBoolean("webdriver.browserdriver.cleanup", "false");
+                
         remoteUserName = propertyLoader.getProperty("remotewebdriver.userName", null);
         remoteApiKey = propertyLoader.getProperty("remotewebdriver.apiKey", null);
 
@@ -150,6 +152,15 @@ public final class WebDriverConfig {
      */
     public boolean isEventLoggingEnabled() {
         return eventLoggingEnabled;
+    }
+    
+    /**
+     * Terminate browser driver.
+     * 
+     * @return is cleanup enabled
+     */
+    public boolean isCleanupDriver() {
+        return cleanupDriver;
     }
     
     /**


### PR DESCRIPTION
@andrew-sumner  has added configuration option to clean up browser driver.  Set by clients as required.

i.e.  Add to config.properties:
 webdriver.browserdriver.cleanup = true

Prior to merge.  Could we test this option out on a Mac?