### PR TITLE
Improve readability/usability of the HttpEasyReader response

### DIFF
--- a/cubano-httpeasy/src/main/java/org/concordion/cubano/driver/http/HttpEasyReader.java
+++ b/cubano-httpeasy/src/main/java/org/concordion/cubano/driver/http/HttpEasyReader.java
@@ -87,6 +87,12 @@ public class HttpEasyReader {
 
     }
 
+    /**
+     * 
+     * @param String from the response stream.
+     * @param contentType from the Http Header.
+     * @return A String (as original), a JsonReader or a XMLReader, depending on the content type.
+     */
     private String formatAsReaderUsingContentType(String asString, String contentType) {
 
         if (contentType != null) {


### PR DESCRIPTION
Depending on the contentType (e.g. json/xml), the response is formatted as either JSON, XML or kept as is.  Enables readability of the logged message. 

Enabled only when logging (of the request/response) is turned on.  