### PR TITLE
Ensure that we use the stream already returned if it is available.

### DIFF
--- a/cubano-httpeasy/src/main/java/org/concordion/cubano/driver/http/HttpEasyReader.java
+++ b/cubano-httpeasy/src/main/java/org/concordion/cubano/driver/http/HttpEasyReader.java
@@ -82,7 +82,7 @@ public class HttpEasyReader {
 
             throw new HttpResponseException(getResponseCode(),
                     "Server returned HTTP response code " + connection.getResponseCode() + ": " + connection.getResponseMessage() +
-                            "\r\nResponse Content: " + asString(connection.getErrorStream()));
+                            "\r\nResponse Content: " + asString());
         }
 
     }


### PR DESCRIPTION
Fixes a bug so that the stream that has already been retrieved / populated is used.  The bug threw a stream.io exception on 'connection.disconnect()'.

Error conditions existed where:
 - logging was turned on
 - response was an error