### PR TITLE
Split trustAllEndPoints into two methods

### DIFF
--- a/cubano-httpeasy/src/main/java/org/concordion/cubano/driver/http/HttpEasyDefaults.java
+++ b/cubano-httpeasy/src/main/java/org/concordion/cubano/driver/http/HttpEasyDefaults.java
@@ -20,7 +20,8 @@ public class HttpEasyDefaults {
     public static final String DEFAULT_PROXY_BYPASS_HOSTS = "localhost,127.0.0.1";
 
     private static String baseUrl = "";
-    private static boolean trustAllEndPoints = false;
+    private static boolean trustAllCertificates = false;
+    private static boolean trustAllHosts = false;
     private static List<String> sensitiveParameters = new ArrayList<>();
 
     // Request authorisation
@@ -41,17 +42,30 @@ public class HttpEasyDefaults {
     private static boolean logRequest = true;
     private static boolean logRequestDetails = false;
 
-
     /**
-     * Skip validation of any SSL certificates and trust all hostnames.
+     * Skip validation of any SSL certificates.
      * Only applies to HTTPS connections.
      *
-     * @param trustAllEndPoints Set to true to trust all certificates and hosts, the default is false
+     * @param trustAllCertificates Set to true to trust all certificates, the default is false
      * @return A self reference
-     * @see HttpEasy#trustAllEndPoints(boolean) to override this setting per request
+     * @see HttpEasy#trustAllCertificates(boolean) to override this setting per request
      */
-    public HttpEasyDefaults trustAllEndPoints(boolean trustAllEndPoints) {
-        HttpEasyDefaults.trustAllEndPoints = trustAllEndPoints;
+    public HttpEasyDefaults trustAllCertificates(boolean trustAllCertificates) {
+        HttpEasyDefaults.trustAllCertificates = trustAllCertificates;
+
+        return this;
+    }
+
+    /**
+     * Trust all hosts.
+     * Only applies to HTTPS connections.
+     *
+     * @param trustAllHosts Set to true to trust all hosts, the default is false
+     * @return A self reference
+     * @see HttpEasy#trustAllHosts(boolean) to override this setting per request
+     */
+    public HttpEasyDefaults trustAllHosts(boolean trustAllHosts) {
+        HttpEasyDefaults.trustAllHosts = trustAllHosts;
 
         return this;
     }
@@ -202,8 +216,12 @@ public class HttpEasyDefaults {
         return this;
     }
 
-    public static boolean isTrustAllEndPoints() {
-        return trustAllEndPoints;
+    public static boolean isTrustAllCertificates() {
+        return trustAllCertificates;
+    }
+
+    public static boolean isTrustAllHosts() {
+        return trustAllHosts;
     }
 
     public static List<String> getSensitiveParameters() {

--- a/cubano-httpeasy/src/test/java/org/concordion/cubano/driver/http/HttpEasyTests.java
+++ b/cubano-httpeasy/src/test/java/org/concordion/cubano/driver/http/HttpEasyTests.java
@@ -22,7 +22,7 @@ public class HttpEasyTests {
      */
     @After
     public void resetStaticState() {
-        HttpEasy.withDefaults().trustAllEndPoints(false);
+        HttpEasy.withDefaults().trustAllCertificates(false).trustAllHosts(false);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class HttpEasyTests {
 
     @Test
     public void trustAllEndPointsOnRequest_FollowingRequestIsTrusted() throws Exception {
-        HttpEasy request = HttpEasy.request().trustAllEndPoints(true);
+        HttpEasy request = HttpEasy.request().trustAllCertificates(true).trustAllHosts(true);
 
         HttpsURLConnection connection = (HttpsURLConnection) getConnection(request, "https://some.where.secure");
 
@@ -69,7 +69,7 @@ public class HttpEasyTests {
 
     @Test
     public void trustAllEndPointsOnRequest_RequestsAfterFollowingRequestAreNotTrusted() throws Exception {
-        HttpEasy request = HttpEasy.request().trustAllEndPoints(true);
+        HttpEasy request = HttpEasy.request().trustAllCertificates(true).trustAllHosts(true);
         @SuppressWarnings("unused")
         HttpsURLConnection connection = (HttpsURLConnection) getConnection(request, "https://some.where.secure");
 
@@ -83,7 +83,7 @@ public class HttpEasyTests {
     @Test
     public void trustAllEndPointsGlobalDefault_FollowingRequestIsTrusted() throws Exception {
         HttpEasy request = HttpEasy.request();
-        HttpEasy.withDefaults().trustAllEndPoints(true);
+        HttpEasy.withDefaults().trustAllCertificates(true).trustAllHosts(true);
 
         HttpsURLConnection connection = (HttpsURLConnection) getConnection(request, "https://some.where.secure");
 
@@ -93,7 +93,7 @@ public class HttpEasyTests {
 
     @Test
     public void trustAllEndPointsGlobalDefault_RequestsAfterFollowingRequestAreTrusted() throws Exception {
-        HttpEasy.withDefaults().trustAllEndPoints(true);
+        HttpEasy.withDefaults().trustAllCertificates(true).trustAllHosts(true);
         HttpEasy request = HttpEasy.request();
         @SuppressWarnings("unused")
         HttpsURLConnection connection = (HttpsURLConnection) getConnection(request, "https://some.where.secure");
@@ -107,8 +107,8 @@ public class HttpEasyTests {
 
     @Test
     public void trustAllEndPointsOnRequest_OverridesGlobalDefault() throws Exception {
-        HttpEasy.withDefaults().trustAllEndPoints(true);
-        HttpEasy request = HttpEasy.request().trustAllEndPoints(false);
+        HttpEasy.withDefaults().trustAllCertificates(true).trustAllHosts(true);
+        HttpEasy request = HttpEasy.request().trustAllCertificates(false).trustAllHosts(false);
 
         HttpsURLConnection connection = (HttpsURLConnection) getConnection(request, "https://some.where.secure");
 


### PR DESCRIPTION
I think combining them was a mistake, so switching back before the next release is created