### PR TITLE
Upgrade Cubano Dependencies affected by upgrade to Selenium 3.141.59

### DIFF
--- a/cubano-webdriver-manager/build.gradle
+++ b/cubano-webdriver-manager/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     compile project(':cubano-webdriver')
 
-    compile 'io.github.bonigarcia:webdrivermanager:2.1.0'    
+    compile 'io.github.bonigarcia:webdrivermanager:3.4.0'    
 }

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/ChromeBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/ChromeBrowserProvider.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 
 import io.github.bonigarcia.wdm.ChromeDriverManager;
+import io.github.bonigarcia.wdm.DriverManagerType;
 
 /**
  * Automatically download, configure and start the WebDriver Manager and browser for Chrome.
@@ -32,7 +33,7 @@ public class ChromeBrowserProvider extends LocalBrowserProvider {
      */
     @Override
     public WebDriver createDriver() {
-        setupBrowserManager(ChromeDriverManager.getInstance());
+        setupBrowserManager(ChromeDriverManager.getInstance(DriverManagerType.CHROME));
 
         ChromeOptions options = new ChromeOptions();
 

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/EdgeBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/EdgeBrowserProvider.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.edge.EdgeOptions;
 
+import io.github.bonigarcia.wdm.DriverManagerType;
 import io.github.bonigarcia.wdm.EdgeDriverManager;
 
 /**
@@ -29,7 +30,7 @@ public class EdgeBrowserProvider extends LocalBrowserProvider {
      */
     @Override
     public WebDriver createDriver() {
-        setupBrowserManager(EdgeDriverManager.getInstance());
+        setupBrowserManager(EdgeDriverManager.getInstance(DriverManagerType.EDGE));
 
         EdgeOptions options = new EdgeOptions();
 

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/FirefoxBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/FirefoxBrowserProvider.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.firefox.ProfilesIni;
 
+import io.github.bonigarcia.wdm.DriverManagerType;
 import io.github.bonigarcia.wdm.FirefoxDriverManager;
 
 /**
@@ -42,7 +43,7 @@ public class FirefoxBrowserProvider extends LocalBrowserProvider {
         boolean useLegacyDriver = getPropertyAsBoolean("useLegacyDriver", "false");
 
         if (!useLegacyDriver) {
-            setupBrowserManager(FirefoxDriverManager.getInstance());
+            setupBrowserManager(FirefoxDriverManager.getInstance(DriverManagerType.FIREFOX));
         }
 
         FirefoxOptions options = new FirefoxOptions();

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/InternetExplorerBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/InternetExplorerBrowserProvider.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.remote.CapabilityType;
 
+import io.github.bonigarcia.wdm.DriverManagerType;
 import io.github.bonigarcia.wdm.InternetExplorerDriverManager;
 
 /**
@@ -30,7 +31,7 @@ public class InternetExplorerBrowserProvider extends LocalBrowserProvider {
      */
     @Override
     public WebDriver createDriver() {
-        setupBrowserManager(InternetExplorerDriverManager.getInstance());
+        setupBrowserManager(InternetExplorerDriverManager.getInstance(DriverManagerType.IEXPLORER));
 
         InternetExplorerOptions options = new InternetExplorerOptions();
 

--- a/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/OperaBrowserProvider.java
+++ b/cubano-webdriver-manager/src/main/java/org/concordion/cubano/driver/web/provider/OperaBrowserProvider.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.opera.OperaDriver;
 import org.openqa.selenium.opera.OperaOptions;
 
+import io.github.bonigarcia.wdm.DriverManagerType;
 import io.github.bonigarcia.wdm.OperaDriverManager;
 
 /**
@@ -29,7 +30,7 @@ public class OperaBrowserProvider extends LocalBrowserProvider {
      */
     @Override
     public WebDriver createDriver() {
-        setupBrowserManager(OperaDriverManager.getInstance());
+        setupBrowserManager(OperaDriverManager.getInstance(DriverManagerType.OPERA));
 
         OperaOptions options = new OperaOptions();
 

--- a/cubano-webdriver/build.gradle
+++ b/cubano-webdriver/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compile "org.seleniumhq.selenium:selenium-java:3.141.59"
     
     // Html Elements
-    compile('ru.yandex.qatools.htmlelements:htmlelements-java:1.19') {
+    compile('ru.yandex.qatools.htmlelements:htmlelements-java:1.20.0') {
         exclude group: 'org.seleniumhq.selenium', module: 'selenium-java'
     }
     


### PR DESCRIPTION

With the Cubano upgrade to 3.141.59, API dependencies needed upgrading, principally due to the way that Selenium has moved away from using its own Clock and Duration classes.  

See https://github.com/SeleniumHQ/selenium/releases and https://github.com/seleniumhq/selenium/commit/59b5002ce4ffd727f96645086dcad300c43504b8 