### PR TITLE
Enable Full Screenshots

### DIFF
--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
@@ -223,7 +223,7 @@ public class PageHelper {
 
         do {
 
-            WebElement frame = (WebElement) ((JavascriptExecutor) this.getTest()).executeScript("return window.frameElement");
+            WebElement frame = (WebElement) ((JavascriptExecutor) this.getTest().getBrowser().getDriver()).executeScript("return window.frameElement");
             // String currentFrame = getCurrentFrameNameOrId();
 
             if (frame == null) {

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
@@ -383,6 +383,16 @@ public class PageHelper {
     }
 
     /**
+     * Get the current frame.
+     *
+     * @param driver WebDriver
+     * @return Null if main document selected otherwise frame WebElement.
+     */
+    public static WebElement getCurrentFrame(WebDriver driver) {
+        return (WebElement) ((JavascriptExecutor) driver).executeScript("return window.frameElement");
+    }
+
+    /**
      * Similar to WebDriver's switchTo().{@link TargetLocator#defaultContent()} but will always select the main document when a page contains iframes.
      */
     public void switchToMainDocument() {

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
@@ -1,7 +1,6 @@
 package org.concordion.cubano.driver.web;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.concordion.cubano.driver.BrowserBasedTest;
@@ -201,8 +200,6 @@ public class PageHelper {
 
     private void capture(ScreenshotTaker screenshotTaker, String description, StoryboardMarker storyboardMarker) {
 
-        List<WebElement> frames = cycleThroughFramesToTheParent();
-
         FluentLogger flogger = pageObject.getLogger().with()
                 .message(description)
                 .screenshot(screenshotTaker)
@@ -213,36 +210,6 @@ public class PageHelper {
         }
 
         flogger.debug();
-
-        cycleThroughFramesToTheChild(frames);
-    }
-
-    private List<WebElement> cycleThroughFramesToTheParent() {
-
-        List<WebElement> frames = new ArrayList<WebElement>();
-
-        do {
-
-            WebElement frame = (WebElement) ((JavascriptExecutor) this.getTest().getBrowser().getDriver()).executeScript("return window.frameElement");
-            // String currentFrame = getCurrentFrameNameOrId();
-
-            if (frame == null) {
-                break;
-            } else {
-                frames.add(frame);
-            }
-
-            this.getTest().getBrowser().getDriver().switchTo().parentFrame();
-
-        } while (true);
-
-        return frames;
-    }
-
-    private void cycleThroughFramesToTheChild(List<WebElement> frames) {
-        for (WebElement frame : frames) {
-            this.getTest().getBrowser().getDriver().switchTo().frame(frame);
-        }
     }
 
     /**

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
@@ -201,7 +201,7 @@ public class PageHelper {
 
     private void capture(ScreenshotTaker screenshotTaker, String description, StoryboardMarker storyboardMarker) {
 
-        List<String> frames = cycleThroughFramesToTheParent();
+        List<WebElement> frames = cycleThroughFramesToTheParent();
 
         FluentLogger flogger = pageObject.getLogger().with()
                 .message(description)
@@ -217,17 +217,19 @@ public class PageHelper {
         cycleThroughFramesToTheChild(frames);
     }
 
-    private List<String> cycleThroughFramesToTheParent() {
+    private List<WebElement> cycleThroughFramesToTheParent() {
 
-        List<String> frames = new ArrayList<String>();
+        List<WebElement> frames = new ArrayList<WebElement>();
 
         do {
-            String currentFrame = getCurrentFrameNameOrId();
 
-            if (currentFrame.isEmpty()) {
+            WebElement frame = (WebElement) ((JavascriptExecutor) this.getTest()).executeScript("return window.frameElement");
+            // String currentFrame = getCurrentFrameNameOrId();
+
+            if (frame == null) {
                 break;
             } else {
-                frames.add(currentFrame);
+                frames.add(frame);
             }
 
             this.getTest().getBrowser().getDriver().switchTo().parentFrame();
@@ -237,8 +239,8 @@ public class PageHelper {
         return frames;
     }
 
-    private void cycleThroughFramesToTheChild(List<String> frames) {
-        for (String frame : frames) {
+    private void cycleThroughFramesToTheChild(List<WebElement> frames) {
+        for (WebElement frame : frames) {
             this.getTest().getBrowser().getDriver().switchTo().frame(frame);
         }
     }

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/SeleniumScreenshotTaker.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/SeleniumScreenshotTaker.java
@@ -5,7 +5,9 @@ import java.awt.Dimension;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -100,7 +102,15 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
 
         byte[] screenshot;
         try {
+
+            // Go out
+            List<WebElement> frames = cycleThroughFramesToTheParent();
+
             screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+
+            // Go back in
+            cycleThroughFramesToTheChild(frames);
+
         } catch (ClassCastException e) {
             throw new ScreenshotUnavailableException("driver does not implement TakesScreenshot");
         }
@@ -124,6 +134,34 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
         //
         // return new Dimension(dest.getWidth(), dest.getHeight());
         // }
+    }
+
+    private List<WebElement> cycleThroughFramesToTheParent() {
+
+        List<WebElement> frames = new ArrayList<WebElement>();
+
+        do {
+
+            WebElement frame = (WebElement) ((JavascriptExecutor) driver).executeScript("return window.frameElement");
+            // String currentFrame = getCurrentFrameNameOrId();
+
+            if (frame == null) {
+                break;
+            } else {
+                frames.add(frame);
+            }
+
+            this.driver.switchTo().parentFrame();
+
+        } while (true);
+
+        return frames;
+    }
+
+    private void cycleThroughFramesToTheChild(List<WebElement> frames) {
+        for (WebElement frame : frames) {
+            driver.switchTo().frame(frame);
+        }
     }
 
     private Dimension getImageDimension(byte[] screenshot) throws IOException {

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/SeleniumScreenshotTaker.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/SeleniumScreenshotTaker.java
@@ -31,10 +31,10 @@ import org.slf4j.LoggerFactory;
  */
 public class SeleniumScreenshotTaker implements ScreenshotTaker {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SeleniumScreenshotTaker.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(SeleniumScreenshotTaker.class);
 
-    private final WebDriver driver;
-    private final WebElement element;
+    protected final WebDriver driver;
+    protected final WebElement element;
 
     /**
      * Constructor.
@@ -69,71 +69,31 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
 
     @Override
     public Dimension writeScreenshotTo(OutputStream outputStream) throws IOException {
-        // TODO Support screenshot of element rather than full page
-
-        // Unfortunately both Ashot and webdriver approaches are not taking iframes into account and are coming up with the
-        // wrong location. I'd also be interested in getting a new AShot ShootingStrategy similar to ViewportPastingDecorator that
-        // works on scrolling web elements and take a 'full' element screenshot by stitching images together
-
-        // Screenshot screenshot;
-        //
-        // try {
-        // if (element == null) {
-        // screenshot = new AShot()
-        // .shootingStrategy(ShootingStrategies.viewportPasting(100))
-        // .takeScreenshot(driver);
-        // } else {
-        // // set custom cropper with indentation and blur filter for indented areas
-        // screenshot = new AShot()
-        // .coordsProvider(new WebDriverCoordsProvider())
-        // .imageCropper(new IndentCropper().addIndentFilter(new BlurFilter()))
-        // .takeScreenshot(driver, element);
-        // }
-        //
-        // ImageIO.write(screenshot.getImage(), "png", outputStream);
-        //
-        // return new Dimension(screenshot.getImage().getWidth(), screenshot.getImage().getHeight());
-        // } catch (Exception e) {
-        // return new Dimension(0, 0);
-        // }
-
         String originalStyle = drawBorderAroundElement();
 
-        byte[] screenshot;
-        try {
+        // Selenium now takes screenshot only of the current frame, we need to go to the main document...
+        Stack<WebElement> frames = cycleThroughFramesToTheParent();
 
-            // Selenium now takes screenshot only of the current frame, we need to go to the main document...
-            Stack<WebElement> frames = cycleThroughFramesToTheParent();
+        // take the screenshot...
+        byte[] screenshot = takeScreenshot();
 
-            // take the screenshot...
-            screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+        // and end up back where we started
+        cycleThroughFramesToTheChild(frames);
 
-            // and end up back where we started
-            cycleThroughFramesToTheChild(frames);
-
-        } catch (ClassCastException e) {
-            throw new ScreenshotUnavailableException("driver does not implement TakesScreenshot");
-        }
-
-        // if (element == null) {
         outputStream.write(screenshot);
 
         removeBorderFromElement(originalStyle);
 
         return getImageDimension(screenshot);
-        // } else {
-        // int imageWidth = element.getSize().getWidth();
-        // int imageHeight = element.getSize().getHeight();
-        // Point point = element.getLocation();
-        // int xcord = point.getX();
-        // int ycord = point.getY();
-        //
-        // BufferedImage bi = getImage(screenshot);
-        // BufferedImage dest = bi.getSubimage(xcord, ycord, imageWidth, imageHeight);
-        // ImageIO.write(dest, "png", outputStream);
-        //
-        // return new Dimension(dest.getWidth(), dest.getHeight());
-        // }
+    }
+
+    protected byte[] takeScreenshot() {
+        try {
+            return ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+        } catch (ClassCastException e) {
+            throw new ScreenshotUnavailableException("driver does not implement TakesScreenshot");
+        }
+
     }
 
     private Stack<WebElement> cycleThroughFramesToTheParent() {
@@ -179,27 +139,6 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
 
         throw new RuntimeException("Unable to read image dimensions");
     }
-
-
-    // private BufferedImage getImage(byte[] screenshot) throws IOException {
-    // try (ImageInputStream in = ImageIO.createImageInputStream(new ByteArrayInputStream(screenshot))) {
-    // final Iterator<ImageReader> readers = ImageIO.getImageReaders(in);
-    // if (readers.hasNext()) {
-    // ImageReader reader = readers.next();
-    // try {
-    // reader.setInput(in);
-    //
-    // return reader.read(0);
-    //
-    // // return new Dimension(reader.getWidth(0), reader.getHeight(0));
-    // } finally {
-    // reader.dispose();
-    // }
-    // }
-    // }
-    //
-    // throw new RuntimeException("Unable to read image dimensions");
-    // }
 
     @Override
     public String getFileExtension() {

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/SeleniumScreenshotTaker.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/SeleniumScreenshotTaker.java
@@ -5,9 +5,8 @@ import java.awt.Dimension;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
+import java.util.Stack;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -103,12 +102,13 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
         byte[] screenshot;
         try {
 
-            // Go out
-            List<WebElement> frames = cycleThroughFramesToTheParent();
+            // Selenium now takes screenshot only of the current frame, we need to go to the main document...
+            Stack<WebElement> frames = cycleThroughFramesToTheParent();
 
+            // take the screenshot...
             screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
 
-            // Go back in
+            // and end up back where we started
             cycleThroughFramesToTheChild(frames);
 
         } catch (ClassCastException e) {
@@ -136,14 +136,12 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
         // }
     }
 
-    private List<WebElement> cycleThroughFramesToTheParent() {
-
-        List<WebElement> frames = new ArrayList<WebElement>();
+    private Stack<WebElement> cycleThroughFramesToTheParent() {
+        Stack<WebElement> frames = new Stack<WebElement>();
 
         do {
 
             WebElement frame = (WebElement) ((JavascriptExecutor) driver).executeScript("return window.frameElement");
-            // String currentFrame = getCurrentFrameNameOrId();
 
             if (frame == null) {
                 break;
@@ -158,9 +156,9 @@ public class SeleniumScreenshotTaker implements ScreenshotTaker {
         return frames;
     }
 
-    private void cycleThroughFramesToTheChild(List<WebElement> frames) {
-        for (WebElement frame : frames) {
-            driver.switchTo().frame(frame);
+    private void cycleThroughFramesToTheChild(Stack<WebElement> frames) {
+        while (frames.size() > 0) {
+            driver.switchTo().frame(frames.pop());
         }
     }
 


### PR DESCRIPTION
@nigelcharman -  @andrew-sumner  and I worked on this together.  So perhaps you might like to review and approve.

The default screenshot behaviour; defines screenshots to be of the current view port only.  When navigation is within a frame, the screenshot captured is only the elements within that frame.  This means that the context of the full page is lost to the consumer viewing the living documentation.

This PR enables taking a full screenshot, in particular when the system under test uses frames.

Just prior to the screenshot being taken, navigate to the parent frame, take the screenshot and then navigate back to the originating frame.  So that ongoing navigation is back at the starting point.

This PR also enables inheritance from SeleniumScreenshotTaker (e,g to enable using APIs like Ashot).