### PR TITLE
Improve Waits for DOM Operations

### DIFF
--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/BasePageObject.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/BasePageObject.java
@@ -11,6 +11,7 @@ import org.concordion.slf4j.ext.ReportLoggerFactory;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriver.TargetLocator;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -323,14 +324,18 @@ public abstract class BasePageObject<T extends BasePageObject<T>> {
 
     /**
      * A convenience method for executing ExpectedConditions.
+     * 
+     * Ignore {@link WebDriverException}. When a DOM operation is happening on the page it may
+     * temporarily cause the element to be inaccessible. Ignore these hierarchy of Exceptions.
      *
-     * @param condition        The expected condition
+     * @param condition The expected condition
      * @param timeOutInSeconds how long to wait for the expected condition to evaluate to true
      * @throws org.openqa.selenium.TimeoutException If the timeout expires
      */
     //CHECKSTYLE:ON
     protected void waitUntil(ExpectedCondition<?> condition, int timeOutInSeconds) {
         WebDriverWait wait = new WebDriverWait(getBrowser().getDriver(), timeOutInSeconds);
+        wait.ignoring(WebDriverException.class);
         wait.until(condition);
     }
 

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
@@ -274,6 +274,9 @@ public class PageHelper {
     /**
      * Wait for the element to be clickable.
      * 
+     * Ignore {@link WebDriverException}. When a DOM operation is happening on a page it may
+     * temporarily cause the element to be inaccessible. Ignore these hierarchy of Exceptions.
+     * 
      * @param webElement The element to check is clickable.
      * @param timeOutInSeconds Timeout in Seconds.
      * 
@@ -429,6 +432,9 @@ public class PageHelper {
     }
 
     private String getClickMessage(WebElement element) {
+
+        waitForElementToClickable(element, 10);
+
         String label = element.getText();
 
         if (label == null || label.isEmpty()) {


### PR DESCRIPTION
When a DOM operation is happening on the page it may temporarily cause the element to be inaccessible. We want to wait for the DOM operation to complete, and ignore the WebDriverException (and
hierarchy), rather than throw the exception.