### PR TITLE
Page helper refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
   - oraclejdk9
   - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-dist: trusty
 jdk:
   - oraclejdk9
   - oraclejdk8

--- a/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
+++ b/cubano-webdriver/src/main/java/org/concordion/cubano/driver/web/PageHelper.java
@@ -277,7 +277,7 @@ public class PageHelper {
 
         capturePage(element, description);
 
-        element.click();
+        waitAndClickElement(element, timeoutSeconds);
 
         if (expectedPage == null) {
             return null;
@@ -302,6 +302,27 @@ public class PageHelper {
                 .until((WebDriver d) -> {
 
                     ExpectedConditions.elementToBeClickable(webElement);
+                    return true;
+
+                });
+    }
+
+    /**
+     * Wait and click the element.
+     * 
+     * Ignore {@link WebDriverException}. When a DOM operation is happening on a page it may
+     * temporarily cause the element to be inaccessible. Ignore these hierarchy of Exceptions.
+     * 
+     * @param webElement Can click the element.
+     * @param timeOutInSeconds Timeout in Seconds.
+     * 
+     */
+    private void waitAndClickElement(WebElement element, int timeoutSeconds) {
+
+        new WebDriverWait(this.pageObject.getBrowser().getDriver(), timeoutSeconds).ignoring(WebDriverException.class)
+                .until((WebDriver d) -> {
+
+                    element.click();
                     return true;
 
                 });


### PR DESCRIPTION
Harden the click of the element by surrounding with a webdriver wait.

For some systems under test, asserting that the element is clickable,
then proceeding is not safe enough.  Need to surround the click with a
wait.